### PR TITLE
feat: support stacks argument

### DIFF
--- a/API.md
+++ b/API.md
@@ -5,7 +5,6 @@
 Name|Description
 ----|-----------
 [DriftMonitor](#cdk-drift-monitor-driftmonitor)|*No description*
-[MonitoredStack](#cdk-drift-monitor-monitoredstack)|*No description*
 
 
 **Structs**
@@ -35,10 +34,11 @@ new DriftMonitor(scope: Construct, id: string, props: DriftMonitorProps)
 * **scope** (<code>[Construct](#aws-cdk-core-construct)</code>)  *No description*
 * **id** (<code>string</code>)  *No description*
 * **props** (<code>[DriftMonitorProps](#cdk-drift-monitor-driftmonitorprops)</code>)  *No description*
-  * **stacks** (<code>Array<[MonitoredStack](#cdk-drift-monitor-monitoredstack)></code>)  List of stack to monitor for CloudFormation drifts. 
   * **alarmOptions** (<code>[CreateAlarmOptions](#aws-cdk-aws-cloudwatch-createalarmoptions)</code>)  Options to create alarm. __*Default*__: alarm on 1 drifted stacks or more, for 3 data points, for
   * **metricNamespace** (<code>string</code>)  Namespace of published metric. __*Default*__: 'DriftMonitor'
   * **runEvery** (<code>[Duration](#aws-cdk-core-duration)</code>)  Run drift detection every X duration. __*Default*__: Duration.hours(1)
+  * **stackNames** (<code>Array<string></code>)  List of stack names to monitor for CloudFormation drifts. __*Optional*__
+  * **stacks** (<code>Array<[Stack](#aws-cdk-core-stack)></code>)  List of stack to monitor for CloudFormation drifts Either stacks or stackNames are required (though not both). __*Optional*__
 
 
 
@@ -51,50 +51,6 @@ Name | Type | Description
 
 
 
-## class MonitoredStack  <a id="cdk-drift-monitor-monitoredstack"></a>
-
-
-
-
-
-### Properties
-
-
-Name | Type | Description 
------|------|-------------
-**name** | <code>string</code> | <span></span>
-
-### Methods
-
-
-#### *static* fromNames(...stackNames) <a id="cdk-drift-monitor-monitoredstack-fromnames"></a>
-
-
-
-```ts
-static fromNames(...stackNames: string[]): Array<MonitoredStack>
-```
-
-* **stackNames** (<code>string</code>)  *No description*
-
-__Returns__:
-* <code>Array<[MonitoredStack](#cdk-drift-monitor-monitoredstack)></code>
-
-#### *static* fromStacks(...stacks) <a id="cdk-drift-monitor-monitoredstack-fromstacks"></a>
-
-
-
-```ts
-static fromStacks(...stacks: Stack[]): Array<MonitoredStack>
-```
-
-* **stacks** (<code>[Stack](#aws-cdk-core-stack)</code>)  *No description*
-
-__Returns__:
-* <code>Array<[MonitoredStack](#cdk-drift-monitor-monitoredstack)></code>
-
-
-
 ## struct DriftMonitorProps  <a id="cdk-drift-monitor-driftmonitorprops"></a>
 
 
@@ -104,10 +60,11 @@ __Returns__:
 
 Name | Type | Description 
 -----|------|-------------
-**stacks** | <code>Array<[MonitoredStack](#cdk-drift-monitor-monitoredstack)></code> | List of stack to monitor for CloudFormation drifts.
 **alarmOptions**? | <code>[CreateAlarmOptions](#aws-cdk-aws-cloudwatch-createalarmoptions)</code> | Options to create alarm.<br/>__*Default*__: alarm on 1 drifted stacks or more, for 3 data points, for
 **metricNamespace**? | <code>string</code> | Namespace of published metric.<br/>__*Default*__: 'DriftMonitor'
 **runEvery**? | <code>[Duration](#aws-cdk-core-duration)</code> | Run drift detection every X duration.<br/>__*Default*__: Duration.hours(1)
+**stackNames**? | <code>Array<string></code> | List of stack names to monitor for CloudFormation drifts.<br/>__*Optional*__
+**stacks**? | <code>Array<[Stack](#aws-cdk-core-stack)></code> | List of stack to monitor for CloudFormation drifts Either stacks or stackNames are required (though not both).<br/>__*Optional*__
 
 
 

--- a/API.md
+++ b/API.md
@@ -5,6 +5,7 @@
 Name|Description
 ----|-----------
 [DriftMonitor](#cdk-drift-monitor-driftmonitor)|*No description*
+[MonitoredStack](#cdk-drift-monitor-monitoredstack)|*No description*
 
 
 **Structs**
@@ -34,7 +35,7 @@ new DriftMonitor(scope: Construct, id: string, props: DriftMonitorProps)
 * **scope** (<code>[Construct](#aws-cdk-core-construct)</code>)  *No description*
 * **id** (<code>string</code>)  *No description*
 * **props** (<code>[DriftMonitorProps](#cdk-drift-monitor-driftmonitorprops)</code>)  *No description*
-  * **stackNames** (<code>Array<string></code>)  List of stack names to monitor for CloudFormation drifts. 
+  * **stacks** (<code>Array<[MonitoredStack](#cdk-drift-monitor-monitoredstack)></code>)  List of stack to monitor for CloudFormation drifts. 
   * **alarmOptions** (<code>[CreateAlarmOptions](#aws-cdk-aws-cloudwatch-createalarmoptions)</code>)  Options to create alarm. __*Default*__: alarm on 1 drifted stacks or more, for 3 data points, for
   * **metricNamespace** (<code>string</code>)  Namespace of published metric. __*Default*__: 'DriftMonitor'
   * **runEvery** (<code>[Duration](#aws-cdk-core-duration)</code>)  Run drift detection every X duration. __*Default*__: Duration.hours(1)
@@ -50,6 +51,50 @@ Name | Type | Description
 
 
 
+## class MonitoredStack  <a id="cdk-drift-monitor-monitoredstack"></a>
+
+
+
+
+
+### Properties
+
+
+Name | Type | Description 
+-----|------|-------------
+**name** | <code>string</code> | <span></span>
+
+### Methods
+
+
+#### *static* fromNames(...stackNames) <a id="cdk-drift-monitor-monitoredstack-fromnames"></a>
+
+
+
+```ts
+static fromNames(...stackNames: string[]): Array<MonitoredStack>
+```
+
+* **stackNames** (<code>string</code>)  *No description*
+
+__Returns__:
+* <code>Array<[MonitoredStack](#cdk-drift-monitor-monitoredstack)></code>
+
+#### *static* fromStacks(...stacks) <a id="cdk-drift-monitor-monitoredstack-fromstacks"></a>
+
+
+
+```ts
+static fromStacks(...stacks: Stack[]): Array<MonitoredStack>
+```
+
+* **stacks** (<code>[Stack](#aws-cdk-core-stack)</code>)  *No description*
+
+__Returns__:
+* <code>Array<[MonitoredStack](#cdk-drift-monitor-monitoredstack)></code>
+
+
+
 ## struct DriftMonitorProps  <a id="cdk-drift-monitor-driftmonitorprops"></a>
 
 
@@ -59,7 +104,7 @@ Name | Type | Description
 
 Name | Type | Description 
 -----|------|-------------
-**stackNames** | <code>Array<string></code> | List of stack names to monitor for CloudFormation drifts.
+**stacks** | <code>Array<[MonitoredStack](#cdk-drift-monitor-monitoredstack)></code> | List of stack to monitor for CloudFormation drifts.
 **alarmOptions**? | <code>[CreateAlarmOptions](#aws-cdk-aws-cloudwatch-createalarmoptions)</code> | Options to create alarm.<br/>__*Default*__: alarm on 1 drifted stacks or more, for 3 data points, for
 **metricNamespace**? | <code>string</code> | Namespace of published metric.<br/>__*Default*__: 'DriftMonitor'
 **runEvery**? | <code>[Duration](#aws-cdk-core-duration)</code> | Run drift detection every X duration.<br/>__*Default*__: Duration.hours(1)

--- a/README.md
+++ b/README.md
@@ -1,18 +1,26 @@
 ## CDK Drift Monitor
 
-Monitors for CloudFormation stack drifts. The construct requires a list of stack names to get started:
+Monitors for CloudFormation stack drifts. The construct requires a list of stacks to get started:
 
 ```typescript
-new DriftMonitor(driftDetectStack, 'CloudFormationDriftMonitor', {
-  stackNames: ['MyStack1', 'MyStack2']
+new DriftMonitor(driftDetectStack, 'DriftMonitor', {
+  stacks: MonitoredStack.fromStacks(myStack1, myStack2),
+});
+```
+
+It can also be initialized by providing stack names:
+
+```typescript
+new DriftMonitor(driftDetectStack, 'DriftMonitor', {
+  stacks: MonitoredStack.fromNames('MyStack1', 'MyStack2'),
 });
 ```
 
 By default, the drift detection will run every hour. This can be customized:
 
 ```typescript
-new DriftMonitor(driftDetectStack, 'CloudFormationDriftMonitor', {
-  stackNames: ['MyStack1', 'MyStack2'],
+new DriftMonitor(driftDetectStack, 'DriftMonitor', {
+  stacks: MonitoredStack.fromStacks(myStack1, myStack2),
   runEvery: Duration.minutes(10),
 });
 ```
@@ -20,8 +28,8 @@ new DriftMonitor(driftDetectStack, 'CloudFormationDriftMonitor', {
 The construct creates an alarm with no actions. Here's an example for adding an alarm action:
 
 ```typescript
-const driftMonitor = new DriftMonitor(driftDetectStack, 'CloudFormationDriftMonitor', {
-  stackNames: ['MyStack1', 'MyStack2'],
+const driftMonitor = new DriftMonitor(driftDetectStack, 'DriftMonitor', {
+  stacks: MonitoredStack.fromStacks(myStack1, myStack2),
   runEvery: Duration.minutes(10),
 });
 driftMonitor.alarm.addAlarmAction(new SnsAction('errorTopic'))

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Monitors for CloudFormation stack drifts. The construct requires a list of stack
 
 ```typescript
 new DriftMonitor(driftDetectStack, 'DriftMonitor', {
-  stacks: MonitoredStack.fromStacks(myStack1, myStack2),
+  stacks: [myStack1, myStack2],
 });
 ```
 
@@ -12,7 +12,7 @@ It can also be initialized by providing stack names:
 
 ```typescript
 new DriftMonitor(driftDetectStack, 'DriftMonitor', {
-  stacks: MonitoredStack.fromNames('MyStack1', 'MyStack2'),
+  stackNames: ['myStack1', 'myStack2'],
 });
 ```
 
@@ -20,7 +20,7 @@ By default, the drift detection will run every hour. This can be customized:
 
 ```typescript
 new DriftMonitor(driftDetectStack, 'DriftMonitor', {
-  stacks: MonitoredStack.fromStacks(myStack1, myStack2),
+  stacks: [myStack1, myStack2],
   runEvery: Duration.minutes(10),
 });
 ```
@@ -29,7 +29,7 @@ The construct creates an alarm with no actions. Here's an example for adding an 
 
 ```typescript
 const driftMonitor = new DriftMonitor(driftDetectStack, 'DriftMonitor', {
-  stacks: MonitoredStack.fromStacks(myStack1, myStack2),
+  stacks: [myStack1, myStack2],
   runEvery: Duration.minutes(10),
 });
 driftMonitor.alarm.addAlarmAction(new SnsAction('errorTopic'))

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@types/node": "^10.17.0",
     "@typescript-eslint/eslint-plugin": "^4.22.0",
     "@typescript-eslint/parser": "^4.22.0",
-    "aws-sdk": "^2.903.0",
+    "aws-sdk": "^2.908.0",
     "esbuild": "^0.11.20",
     "eslint": "^7.25.0",
     "eslint-import-resolver-node": "^0.3.4",

--- a/test/__snapshots__/drift-monitor.test.ts.snap
+++ b/test/__snapshots__/drift-monitor.test.ts.snap
@@ -3,16 +3,16 @@
 exports[`snapshot test 1`] = `
 Object {
   "Parameters": Object {
-    "AssetParameters55d401d24f99ce3e2bdad32dc5a32a2d9abc8974fbb7b0c524a224e06eea3299ArtifactHash488EA16A": Object {
-      "Description": "Artifact hash for asset \\"55d401d24f99ce3e2bdad32dc5a32a2d9abc8974fbb7b0c524a224e06eea3299\\"",
+    "AssetParameters70c707ee9c0d3f0576fdd17ddd57e110f9010330fd49c649b33490a92d66c146ArtifactHash6DB7FF6B": Object {
+      "Description": "Artifact hash for asset \\"70c707ee9c0d3f0576fdd17ddd57e110f9010330fd49c649b33490a92d66c146\\"",
       "Type": "String",
     },
-    "AssetParameters55d401d24f99ce3e2bdad32dc5a32a2d9abc8974fbb7b0c524a224e06eea3299S3Bucket9A1058FD": Object {
-      "Description": "S3 bucket for asset \\"55d401d24f99ce3e2bdad32dc5a32a2d9abc8974fbb7b0c524a224e06eea3299\\"",
+    "AssetParameters70c707ee9c0d3f0576fdd17ddd57e110f9010330fd49c649b33490a92d66c146S3Bucket000AF63E": Object {
+      "Description": "S3 bucket for asset \\"70c707ee9c0d3f0576fdd17ddd57e110f9010330fd49c649b33490a92d66c146\\"",
       "Type": "String",
     },
-    "AssetParameters55d401d24f99ce3e2bdad32dc5a32a2d9abc8974fbb7b0c524a224e06eea3299S3VersionKeyDAF010CE": Object {
-      "Description": "S3 key for asset version \\"55d401d24f99ce3e2bdad32dc5a32a2d9abc8974fbb7b0c524a224e06eea3299\\"",
+    "AssetParameters70c707ee9c0d3f0576fdd17ddd57e110f9010330fd49c649b33490a92d66c146S3VersionKey0C5354F5": Object {
+      "Description": "S3 key for asset version \\"70c707ee9c0d3f0576fdd17ddd57e110f9010330fd49c649b33490a92d66c146\\"",
       "Type": "String",
     },
   },
@@ -24,7 +24,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters55d401d24f99ce3e2bdad32dc5a32a2d9abc8974fbb7b0c524a224e06eea3299S3Bucket9A1058FD",
+            "Ref": "AssetParameters70c707ee9c0d3f0576fdd17ddd57e110f9010330fd49c649b33490a92d66c146S3Bucket000AF63E",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -37,7 +37,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters55d401d24f99ce3e2bdad32dc5a32a2d9abc8974fbb7b0c524a224e06eea3299S3VersionKeyDAF010CE",
+                          "Ref": "AssetParameters70c707ee9c0d3f0576fdd17ddd57e110f9010330fd49c649b33490a92d66c146S3VersionKey0C5354F5",
                         },
                       ],
                     },
@@ -50,7 +50,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters55d401d24f99ce3e2bdad32dc5a32a2d9abc8974fbb7b0c524a224e06eea3299S3VersionKeyDAF010CE",
+                          "Ref": "AssetParameters70c707ee9c0d3f0576fdd17ddd57e110f9010330fd49c649b33490a92d66c146S3VersionKey0C5354F5",
                         },
                       ],
                     },

--- a/test/drift-monitor.test.ts
+++ b/test/drift-monitor.test.ts
@@ -1,14 +1,16 @@
 import { SynthUtils } from '@aws-cdk/assert';
 import { Duration, Stack } from '@aws-cdk/core';
 import '@aws-cdk/assert/jest';
-import { DriftMonitor } from '../src';
+import { DriftMonitor, MonitoredStack } from '../src';
 
 test('snapshot test', () => {
   // GIVEN
   const stack = new Stack();
 
   // WHEN
-  new DriftMonitor(stack, 'DriftMonitor', { stackNames: ['stack1', 'stack2'] });
+  new DriftMonitor(stack, 'DriftMonitor', {
+    stacks: MonitoredStack.fromNames('stack1', 'stack2'),
+  });
   const cfnArtifact = SynthUtils.synthesize(stack);
 
   // THEN
@@ -20,7 +22,9 @@ test('lambda is created with expected environment variables', () => {
   const stack = new Stack();
 
   // WHEN
-  new DriftMonitor(stack, 'DriftMonitor', { stackNames: ['stack1', 'stack2'] });
+  new DriftMonitor(stack, 'DriftMonitor', {
+    stacks: MonitoredStack.fromNames('stack1', 'stack2'),
+  });
 
   // THEN
   expect(stack).toHaveResource('AWS::Lambda::Function', {
@@ -38,7 +42,10 @@ test('when given metric namespace then lambda is created with expected environme
   const stack = new Stack();
 
   // WHEN
-  new DriftMonitor(stack, 'DriftMonitor', { stackNames: ['stack1', 'stack2'], metricNamespace: 'customMetricNamespace' });
+  new DriftMonitor(stack, 'DriftMonitor', {
+    stacks: MonitoredStack.fromNames('stack1', 'stack2'),
+    metricNamespace: 'customMetricNamespace',
+  });
 
   // THEN
   expect(stack).toHaveResource('AWS::Lambda::Function', {
@@ -56,7 +63,9 @@ test('when no runEvery argument then lambda is scheduled to run every hour by de
   const stack = new Stack();
 
   // WHEN
-  new DriftMonitor(stack, 'DriftMonitor', { stackNames: ['stack1', 'stack2'] });
+  new DriftMonitor(stack, 'DriftMonitor', {
+    stacks: MonitoredStack.fromNames('stack1', 'stack2'),
+  });
 
   // THEN
   expect(stack).toHaveResource('AWS::Events::Rule', {
@@ -70,7 +79,9 @@ test('when stackNames is empty then construct throws', () => {
 
   // WHEN / THEN
   expect(() => {
-    new DriftMonitor(stack, 'DriftMonitor', { stackNames: [] });
+    new DriftMonitor(stack, 'DriftMonitor', {
+      stacks: [],
+    });
   }).toThrow();
 });
 
@@ -81,7 +92,7 @@ test('when runEvery < 1 minute then construct throws', () => {
   // WHEN / THEN
   expect(() => {
     new DriftMonitor(stack, 'DriftMonitor', {
-      stackNames: ['stack1', 'stack2'],
+      stacks: MonitoredStack.fromNames('stack1', 'stack2'),
       runEvery: Duration.seconds(59),
     });
   }).toThrow();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1667,10 +1667,10 @@ available-typed-arrays@^1.0.2:
   dependencies:
     array-filter "^1.0.0"
 
-aws-sdk@^2.903.0:
-  version "2.906.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.906.0.tgz#c85ebb6257865b97d6a88c6d89aeb9b6075744df"
-  integrity sha512-u/kmVILew/9HFpHwVrc3VMK24m+XrazXEooMxkzbWXEBvtVm1xTYv8xPmdgiYvogWIkWTkeIF9ME4LBeHenYkw==
+aws-sdk@^2.908.0:
+  version "2.908.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.908.0.tgz#7c1772919f2840d322a678b27625ef16a0047949"
+  integrity sha512-+UtrKOlwjFhGRRrtf3zl5iwFcAnvuh9m63gBnFj9aA+scbP4K2qOukJxPqXCBDeFPqLGH+ojmMJE/54oSlOfmQ==
   dependencies:
     buffer "4.9.2"
     events "1.1.1"


### PR DESCRIPTION
Following comment on [pr#7](https://github.com/cdklabs/cdk-drift-monitor/pull/7), construct API should be flexible enough to support both `Stack` objects and stack string names.

Normally the commit message prefix should be `BREAKING CHANGE`, however since the package is still in early stage and is yet to be used, prefixed with `feat` instead.