### PR TITLE
chore: support more forms of runEvery duration

### DIFF
--- a/src/drift-monitor.ts
+++ b/src/drift-monitor.ts
@@ -499,19 +499,20 @@ export class DriftMonitor extends Construct {
    * @return Duration - the closest CloudWatch period.
    */
   private getClosestCloudWatchMetricPeriod(duration: Duration) {
-    if (duration.toMinutes() <= 1) {
+    const timeConversionOptions = { integral: false };
+    if (duration.toMinutes(timeConversionOptions) <= 1) {
       return Duration.minutes(1);
-    } if (duration.toMinutes() <= 5) {
+    } if (duration.toMinutes(timeConversionOptions) <= 5) {
       return Duration.minutes(5);
-    } else if (duration.toMinutes() <= 15) {
+    } else if (duration.toMinutes(timeConversionOptions) <= 15) {
       return Duration.minutes(15);
-    } else if (duration.toMinutes() <= 60) {
+    } else if (duration.toHours(timeConversionOptions) <= 1) {
       return Duration.hours(1);
-    } else if (duration.toHours() <= 6) {
+    } else if (duration.toHours(timeConversionOptions) <= 6) {
       return Duration.hours(6);
-    } else if (duration.toHours() <= 24) {
+    } else if (duration.toDays(timeConversionOptions) <= 1) {
       return Duration.days(1);
-    } else if (duration.toDays() <= 7) {
+    } else if (duration.toDays(timeConversionOptions) <= 7) {
       return Duration.days(7);
     } else {
       return Duration.days(30);

--- a/test/drift-monitor.test.ts
+++ b/test/drift-monitor.test.ts
@@ -284,6 +284,22 @@ describe('runEvery CloudWatch metric period tests', () => {
     });
   });
 
+  test('when runEvery 61 minutes then period is 6 hour', () => {
+    // GIVEN
+    const stack = new Stack();
+
+    // WHEN
+    new DriftMonitor(stack, 'DriftMonitor', {
+      stackNames: ['stack1'],
+      runEvery: Duration.minutes(61),
+    });
+
+    // THEN
+    expect(stack).toHaveResourceLike('AWS::CloudWatch::Alarm', {
+      Period: Duration.hours(6).toSeconds(),
+    });
+  });
+
   test('when runEvery 5 hours then period is 6 hour', () => {
     // GIVEN
     const stack = new Stack();


### PR DESCRIPTION
Related discussion at [pr#28](https://github.com/cdklabs/cdk-drift-monitor/pull/28)