### PR TITLE
chore: fix snapshot

### DIFF
--- a/test/__snapshots__/drift-monitor.test.ts.snap
+++ b/test/__snapshots__/drift-monitor.test.ts.snap
@@ -3,16 +3,16 @@
 exports[`snapshot test 1`] = `
 Object {
   "Parameters": Object {
-    "AssetParameters3ec0d4c281927761911a0e55de5cd54296982146ffec84710ba791f6f6cdf57aArtifactHash861D7656": Object {
-      "Description": "Artifact hash for asset \\"3ec0d4c281927761911a0e55de5cd54296982146ffec84710ba791f6f6cdf57a\\"",
+    "AssetParameters2cedbd2714b71211111b2609299533429b4e48457b65220d7e5eb95da28d9137ArtifactHashF8C64B48": Object {
+      "Description": "Artifact hash for asset \\"2cedbd2714b71211111b2609299533429b4e48457b65220d7e5eb95da28d9137\\"",
       "Type": "String",
     },
-    "AssetParameters3ec0d4c281927761911a0e55de5cd54296982146ffec84710ba791f6f6cdf57aS3Bucket90099BC2": Object {
-      "Description": "S3 bucket for asset \\"3ec0d4c281927761911a0e55de5cd54296982146ffec84710ba791f6f6cdf57a\\"",
+    "AssetParameters2cedbd2714b71211111b2609299533429b4e48457b65220d7e5eb95da28d9137S3BucketED675499": Object {
+      "Description": "S3 bucket for asset \\"2cedbd2714b71211111b2609299533429b4e48457b65220d7e5eb95da28d9137\\"",
       "Type": "String",
     },
-    "AssetParameters3ec0d4c281927761911a0e55de5cd54296982146ffec84710ba791f6f6cdf57aS3VersionKey11E9AE23": Object {
-      "Description": "S3 key for asset version \\"3ec0d4c281927761911a0e55de5cd54296982146ffec84710ba791f6f6cdf57a\\"",
+    "AssetParameters2cedbd2714b71211111b2609299533429b4e48457b65220d7e5eb95da28d9137S3VersionKey82693E54": Object {
+      "Description": "S3 key for asset version \\"2cedbd2714b71211111b2609299533429b4e48457b65220d7e5eb95da28d9137\\"",
       "Type": "String",
     },
   },
@@ -24,7 +24,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters3ec0d4c281927761911a0e55de5cd54296982146ffec84710ba791f6f6cdf57aS3Bucket90099BC2",
+            "Ref": "AssetParameters2cedbd2714b71211111b2609299533429b4e48457b65220d7e5eb95da28d9137S3BucketED675499",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -37,7 +37,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters3ec0d4c281927761911a0e55de5cd54296982146ffec84710ba791f6f6cdf57aS3VersionKey11E9AE23",
+                          "Ref": "AssetParameters2cedbd2714b71211111b2609299533429b4e48457b65220d7e5eb95da28d9137S3VersionKey82693E54",
                         },
                       ],
                     },
@@ -50,7 +50,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters3ec0d4c281927761911a0e55de5cd54296982146ffec84710ba791f6f6cdf57aS3VersionKey11E9AE23",
+                          "Ref": "AssetParameters2cedbd2714b71211111b2609299533429b4e48457b65220d7e5eb95da28d9137S3VersionKey82693E54",
                         },
                       ],
                     },

--- a/test/__snapshots__/drift-monitor.test.ts.snap
+++ b/test/__snapshots__/drift-monitor.test.ts.snap
@@ -3,16 +3,16 @@
 exports[`snapshot test 1`] = `
 Object {
   "Parameters": Object {
-    "AssetParameters75a81ff9564c6ce56c3acefe59eed2e3fb9834466a458464d0b89a4deeda944cArtifactHash854BDC7A": Object {
-      "Description": "Artifact hash for asset \\"75a81ff9564c6ce56c3acefe59eed2e3fb9834466a458464d0b89a4deeda944c\\"",
+    "AssetParameters3ec0d4c281927761911a0e55de5cd54296982146ffec84710ba791f6f6cdf57aArtifactHash861D7656": Object {
+      "Description": "Artifact hash for asset \\"3ec0d4c281927761911a0e55de5cd54296982146ffec84710ba791f6f6cdf57a\\"",
       "Type": "String",
     },
-    "AssetParameters75a81ff9564c6ce56c3acefe59eed2e3fb9834466a458464d0b89a4deeda944cS3Bucket571AB454": Object {
-      "Description": "S3 bucket for asset \\"75a81ff9564c6ce56c3acefe59eed2e3fb9834466a458464d0b89a4deeda944c\\"",
+    "AssetParameters3ec0d4c281927761911a0e55de5cd54296982146ffec84710ba791f6f6cdf57aS3Bucket90099BC2": Object {
+      "Description": "S3 bucket for asset \\"3ec0d4c281927761911a0e55de5cd54296982146ffec84710ba791f6f6cdf57a\\"",
       "Type": "String",
     },
-    "AssetParameters75a81ff9564c6ce56c3acefe59eed2e3fb9834466a458464d0b89a4deeda944cS3VersionKeyA3B7ABD7": Object {
-      "Description": "S3 key for asset version \\"75a81ff9564c6ce56c3acefe59eed2e3fb9834466a458464d0b89a4deeda944c\\"",
+    "AssetParameters3ec0d4c281927761911a0e55de5cd54296982146ffec84710ba791f6f6cdf57aS3VersionKey11E9AE23": Object {
+      "Description": "S3 key for asset version \\"3ec0d4c281927761911a0e55de5cd54296982146ffec84710ba791f6f6cdf57a\\"",
       "Type": "String",
     },
   },
@@ -24,7 +24,7 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParameters75a81ff9564c6ce56c3acefe59eed2e3fb9834466a458464d0b89a4deeda944cS3Bucket571AB454",
+            "Ref": "AssetParameters3ec0d4c281927761911a0e55de5cd54296982146ffec84710ba791f6f6cdf57aS3Bucket90099BC2",
           },
           "S3Key": Object {
             "Fn::Join": Array [
@@ -37,7 +37,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters75a81ff9564c6ce56c3acefe59eed2e3fb9834466a458464d0b89a4deeda944cS3VersionKeyA3B7ABD7",
+                          "Ref": "AssetParameters3ec0d4c281927761911a0e55de5cd54296982146ffec84710ba791f6f6cdf57aS3VersionKey11E9AE23",
                         },
                       ],
                     },
@@ -50,7 +50,7 @@ Object {
                       "Fn::Split": Array [
                         "||",
                         Object {
-                          "Ref": "AssetParameters75a81ff9564c6ce56c3acefe59eed2e3fb9834466a458464d0b89a4deeda944cS3VersionKeyA3B7ABD7",
+                          "Ref": "AssetParameters3ec0d4c281927761911a0e55de5cd54296982146ffec84710ba791f6f6cdf57aS3VersionKey11E9AE23",
                         },
                       ],
                     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5298,7 +5298,7 @@ lodash.truncate@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
 
-lodash@4.x, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.7.0:
+lodash@4.x, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.21, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
[this commit](https://github.com/cdklabs/cdk-drift-monitor/commit/5e701c2a718372e1f7b7bea901cfe9175a2efe88), made by an automation, incorrectly updated test snapshot, causing build to fail.

This commit is the result of running `npx projen build` and committing an up-to-date snapshot